### PR TITLE
support copy svg to clipboard and add settings tab to configure scaling factor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "copy-image",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "copy-image",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"jimp": "^1.6.0"


### PR DESCRIPTION
copy SVG to clipboard by:

1. use canvas to draw the SVG
2. convert canvas to PNG blob



The canvas size is determined by scaling factor `this.settings.svgToPngScale`, which is default to 4. The default canvas size is 1200x1200.



The scaling factor can be configured through newly added settings tab, ranging from 1 to 10.

Fix #7.

